### PR TITLE
Fix: tts 버그 수정

### DIFF
--- a/Assets/ViewAssets.swift
+++ b/Assets/ViewAssets.swift
@@ -38,11 +38,11 @@ class MyTimer: ObservableObject {
 
 struct MainBox : View{
     @ObservedObject var myTimer = MyTimer()
+    let speak = AVSpeechSynthesizer()
     var text: String
     var body: some View{
         HStack {
             Button(action : {
-                let speak = AVSpeechSynthesizer()
                 speak.stopSpeaking(at: .immediate)
                 let utterence = AVSpeechUtterance(string: text)
                 utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
@@ -93,7 +93,7 @@ struct SolBox: View{
     var letterSecond: String = ""
     @Binding var check1: Bool
     @Binding var check2: Bool
-    
+    let speak = AVSpeechSynthesizer()
     
     
     
@@ -104,7 +104,7 @@ struct SolBox: View{
                 let utterence = AVSpeechUtterance(string: letterFirst)
                 utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
                 
-                let speak = AVSpeechSynthesizer()
+                
                 if(self.firstTimer.value < 3){
                     utterence.rate = 0.1
                 }
@@ -150,7 +150,6 @@ struct SolBox: View{
                 let utterence = AVSpeechUtterance(string: letterSecond)
                 utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
                 
-                let speak = AVSpeechSynthesizer()
                 if(self.secondTimer.value < 3){
                     utterence.rate = 0.1
                 }
@@ -212,12 +211,12 @@ struct EditBox: View{
     @ObservedObject var myTimer = MyTimer()
     let soundplayer = SoundPlayer()
     @Binding var check: Bool
+    let speak = AVSpeechSynthesizer()
     
     var body: some View{
         HStack{
             if check {
                 Button(action : {
-                    let speak = AVSpeechSynthesizer()
                     speak.stopSpeaking(at: .immediate)
                     let utterence = AVSpeechUtterance(string: text)
                     utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
@@ -300,7 +299,7 @@ struct BodyBox: View{
     @State var buttonArray: [Bool] = [false, false, false, false, false, false, false, false, false, false, false, false, true]
     @State var letterArray: [String]
     @State var secondArray = [false, false, false, false, false, false, false, false, false, false, false, false, true]
-    
+    let speak = AVSpeechSynthesizer()
 
     
     
@@ -344,7 +343,7 @@ struct BodyBox: View{
                         let utterence = AVSpeechUtterance(string: han.word)
                         utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
                         
-                        let speak = AVSpeechSynthesizer()
+
                         if(self.myTimer.value < 3){
                             utterence.rate = 0.1
                         }
@@ -404,7 +403,6 @@ struct BodyBox: View{
                                     let utterence = AVSpeechUtterance(string: han.word)
                                     utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
                                     utterence.rate = 0.4
-                                    let speak = AVSpeechSynthesizer()
                                     speak.speak(utterence)
                                 }else{
                                     showAlert.toggle()
@@ -429,7 +427,6 @@ struct BodyBox: View{
                                     let utterence = AVSpeechUtterance(string: letterFirst)
                                     utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
                                     utterence.rate = 0.4
-                                    let speak = AVSpeechSynthesizer()
                                     speak.speak(utterence)
                                     buttonArray = [false, false, false, false, false, false, false, false, false, false, false, false, true]
                                 }else{

--- a/Hangeul.xcodeproj/project.pbxproj
+++ b/Hangeul.xcodeproj/project.pbxproj
@@ -488,7 +488,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = edu.coin.Hangeul;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -520,7 +520,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = edu.coin.Hangeul;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Hangeul/ClearView.swift
+++ b/Hangeul/ClearView.swift
@@ -22,6 +22,7 @@ struct ClearView: View {
     @Binding var num: [Int]
     let soundplayer = SoundPlayer()
     @State var showModal = false
+    let speak = AVSpeechSynthesizer()
     
     var body: some View {
 //        NavigationView{
@@ -37,7 +38,6 @@ struct ClearView: View {
                 Button(action : {
                     let utterence = AVSpeechUtterance(string: "성공")
                     utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
-                    let speak = AVSpeechSynthesizer()
                     if(self.Timer.value < 3){
                         utterence.rate = 0.1
                     }
@@ -71,7 +71,6 @@ struct ClearView: View {
                 Button(action : {
                     let utterence = AVSpeechUtterance(string: hangeuls[num[4]].word)
                     utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
-                    let speak = AVSpeechSynthesizer()
                     if(self.Timer1.value < 3){
                         utterence.rate = 0.1
                     }
@@ -102,7 +101,6 @@ struct ClearView: View {
                 Button(action : {
                     let utterence = AVSpeechUtterance(string: hangeuls[num[3]].word)
                     utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
-                    let speak = AVSpeechSynthesizer()
                     if(self.Timer2.value < 3){
                         utterence.rate = 0.1
                     }
@@ -127,7 +125,6 @@ struct ClearView: View {
                 Button(action : {
                     let utterence = AVSpeechUtterance(string: hangeuls[num[2]].word)
                     utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
-                    let speak = AVSpeechSynthesizer()
                     if(self.Timer3.value < 3){
                         utterence.rate = 0.1
                     }
@@ -155,7 +152,6 @@ struct ClearView: View {
                     Button(action : {
                         let utterence = AVSpeechUtterance(string: hangeuls[num[1]].word)
                         utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
-                        let speak = AVSpeechSynthesizer()
                         if(self.Timer4.value < 3){
                             utterence.rate = 0.1
                         }
@@ -180,7 +176,6 @@ struct ClearView: View {
                     Button(action : {
                         let utterence = AVSpeechUtterance(string: hangeuls[num[0]].word)
                         utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
-                        let speak = AVSpeechSynthesizer()
                         if(self.Timer5.value < 3){
                             utterence.rate = 0.1
                         }

--- a/Hangeul/LettersView.swift
+++ b/Hangeul/LettersView.swift
@@ -90,11 +90,10 @@ struct LettersBox: View{
     
     @ObservedObject var myTimer = MyTimer()
     var letter: String
-    
+    let speak = AVSpeechSynthesizer()
     var body: some View{
         Button(action : {
             
-            let speak = AVSpeechSynthesizer()
             speak.stopSpeaking(at: .immediate)
             let utterence = AVSpeechUtterance(string: letter)
             utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")


### PR DESCRIPTION
## Outline
- #5 

## Work Contents
- 사운드 출력 버튼을 눌렀을때 사운드가 출력되지 않음

## Trouble Point 
### 1.  TTS가 동작하지 않는다.

  - **Trouble Situation**
    -  iOS 16 업데이트 이후 AVSpeechSynthesizer가 함수 내에 local로 선언되어 있다면 함수가 종료될 때 할당이 즉시 해제되어 AVSpeechSynthesizer가 미쳐 speak를 끝까지 출력하지 못한다.

 - **Trouble Shooting**
    - AVSpeechSynthesizer를 함수 내에 local 변수로 선언하는 것이 아니라 instance로 선언하여 AVSpeechSynthesizer의 할당이 함수가 종료될 때 해제되지 않도록 하니 해결되었다.

   
```swift
let synthesizer = AVSpeechSynthesizer()

func pronounce(_ letter: String) {
        let utterance = AVSpeechUtterance(string: letter)
        utterance.voice = AVSpeechSynthesisVoice(language: "ko-KR")

        utterance.volume = 30
        utterance.rate = 0.4
        synthesizer.speak(utterance)
}
```