### PR TITLE
Bug: #7 iOS 16.1 업데이트 이후 지속적으로 발생하고 있는 충돌 해결

### DIFF
--- a/Hangeul/ClearView.swift
+++ b/Hangeul/ClearView.swift
@@ -25,15 +25,9 @@ struct ClearView: View {
     let speak = AVSpeechSynthesizer()
     
     var body: some View {
-//        NavigationView{
         ZStack{
-            if #available(iOS 14.0, *) {
-                ColorManage.background
-                    .ignoresSafeArea()
-            } else {
-                ColorManage.background
-                    .edgesIgnoringSafeArea(.all)
-            }
+            ColorManage.background
+                .ignoresSafeArea()
             VStack{
                 Button(action : {
                     let utterence = AVSpeechUtterance(string: "성공")
@@ -48,7 +42,7 @@ struct ClearView: View {
                     speak.speak(utterence)
                     self.Timer.value = 0
                 }){
-                    HStack {
+                    HStack{
                         ZStack{
                             RoundedRectangle(cornerRadius: 10.0)
                                 .fill(ColorManage.button)
@@ -61,93 +55,102 @@ struct ClearView: View {
                                     .font(.system(size: UIScreen.screenWidth * 0.1))
                             }
                         }
-                    }.frame(width: UIScreen.screenWidth * 0.90, height: UIScreen.screenHeight * 0.25)
+                    }
+                    .frame(width: UIScreen.screenWidth * 0.90, height: UIScreen.screenHeight * 0.25)
                     .padding(.bottom, UIScreen.screenHeight * 0.03)
                     .padding([.leading, .trailing], UIScreen.screenWidth * 0.05 )
                 }
-            
-                
-            HStack{
-                Button(action : {
-                    let utterence = AVSpeechUtterance(string: hangeuls[num[4]].word)
-                    utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
-                    if(self.Timer1.value < 3){
-                        utterence.rate = 0.1
-                    }
-                    else{
-                        utterence.rate = 0.5
-                    }
-                    
-                    speak.speak(utterence)
-                    self.Timer1.value = 0
-                }){
-                ZStack{
-                        RoundedRectangle(cornerRadius: 10.0)
-                        .fill(ColorManage.button)
-                        VStack{
-                            Text("\(hangeuls[num[4]].word)")
-                                .foregroundColor(ColorManage.buttontext)
-                                .font(.system(size: UIScreen.screenWidth * 0.13))
-                                .opacity(0.6)
-                        }
-                }
-                }.frame(width: UIScreen.screenHeight * 0.23, height: UIScreen.screenHeight * 0.09)
                 
                 
-            }
-            .padding(.bottom, UIScreen.screenHeight * 0.015)
-            .padding([.leading, .trailing], UIScreen.screenWidth * 0.05 )
-            HStack{
-                Button(action : {
-                    let utterence = AVSpeechUtterance(string: hangeuls[num[3]].word)
-                    utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
-                    if(self.Timer2.value < 3){
-                        utterence.rate = 0.1
-                    }
-                    else{
-                        utterence.rate = 0.5
-                    }
-                    
-                    speak.speak(utterence)
-                    self.Timer2.value = 0
-                }){
-                ZStack{
-                        RoundedRectangle(cornerRadius: 10.0)
-                        .fill(ColorManage.button)
-                        VStack{
-                            Text("\(hangeuls[num[3]].word)")
-                                .foregroundColor(ColorManage.buttontext)
-                                .font(.system(size: UIScreen.screenWidth * 0.13))
-                                .opacity(0.6)
+                HStack{
+                    Button(action : {
+                        let utterence = AVSpeechUtterance(string: hangeuls[num[4]].word)
+                        utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
+                        if(self.Timer1.value < 3) {
+                            utterence.rate = 0.1
                         }
-                }
-                }.frame(width: UIScreen.screenWidth * 0.45, height: UIScreen.screenHeight * 0.09)
-                Button(action : {
-                    let utterence = AVSpeechUtterance(string: hangeuls[num[2]].word)
-                    utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
-                    if(self.Timer3.value < 3){
-                        utterence.rate = 0.1
-                    }
-                    else{
-                        utterence.rate = 0.5
-                    }
-                    
-                    speak.speak(utterence)
-                    self.Timer3.value = 0
-                }){
-                ZStack{
-                        RoundedRectangle(cornerRadius: 10.0)
-                        .fill(ColorManage.button)
-                        VStack{
-                            Text("\(hangeuls[num[2]].word)")
-                                .foregroundColor(ColorManage.buttontext)
-                                .font(.system(size: UIScreen.screenWidth * 0.13))
-                                .opacity(0.6)
+                        else {
+                            utterence.rate = 0.5
                         }
+                        
+                        speak.speak(utterence)
+                        self.Timer1.value = 0
+                    }){
+                        ZStack{
+                            RoundedRectangle(cornerRadius: 10.0)
+                                .fill(ColorManage.button)
+                            VStack{
+                                if num.count > 4 {
+                                    Text("\(hangeuls[num[4]].word)")
+                                        .foregroundColor(ColorManage.buttontext)
+                                        .font(.system(size: UIScreen.screenWidth * 0.13))
+                                        .opacity(0.6)
+                                }
+                            }
+                        }
+                    }
+                    .frame(width: UIScreen.screenHeight * 0.23, height: UIScreen.screenHeight * 0.09)
                 }
-                }.frame(width: UIScreen.screenWidth * 0.45, height: UIScreen.screenHeight * 0.09)
-            }.padding(.bottom, UIScreen.screenHeight * 0.015)
-                    .padding([.leading, .trailing], UIScreen.screenWidth * 0.05 )
+                .padding(.bottom, UIScreen.screenHeight * 0.015)
+                .padding([.leading, .trailing], UIScreen.screenWidth * 0.05 )
+                HStack{
+                    Button(action : {
+                        let utterence = AVSpeechUtterance(string: hangeuls[num[3]].word)
+                        utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
+                        if(self.Timer2.value < 3){
+                            utterence.rate = 0.1
+                        }
+                        else{
+                            utterence.rate = 0.5
+                        }
+                        
+                        speak.speak(utterence)
+                        self.Timer2.value = 0
+                    }){
+                        ZStack{
+                            RoundedRectangle(cornerRadius: 10.0)
+                                .fill(ColorManage.button)
+                            VStack{
+                                if num.count > 4 {
+                                    Text("\(hangeuls[num[3]].word)")
+                                        .foregroundColor(ColorManage.buttontext)
+                                        .font(.system(size: UIScreen.screenWidth * 0.13))
+                                        .opacity(0.6)
+                                }
+                            }
+                        }
+                    }
+                    .frame(width: UIScreen.screenWidth * 0.45, height: UIScreen.screenHeight * 0.09)
+                    Button(action : {
+                        let utterence = AVSpeechUtterance(string: hangeuls[num[2]].word)
+                        utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
+                        if(self.Timer3.value < 3) {
+                            utterence.rate = 0.1
+                        }
+                        else {
+                            utterence.rate = 0.5
+                        }
+                        
+                        speak.speak(utterence)
+                        self.Timer3.value = 0
+                    }){
+                        ZStack{
+                            RoundedRectangle(cornerRadius: 10.0)
+                                .fill(ColorManage.button)
+                            VStack{
+                                if num.count > 4 {
+                                    Text("\(hangeuls[num[2]].word)")
+                                        .foregroundColor(ColorManage.buttontext)
+                                        .font(.system(size: UIScreen.screenWidth * 0.13))
+                                        .opacity(0.6)
+                                }
+                            }
+                        }
+                    }
+                    .frame(width: UIScreen.screenWidth * 0.45, height: UIScreen.screenHeight * 0.09)
+                }
+                .padding(.bottom, UIScreen.screenHeight * 0.015)
+                .padding([.leading, .trailing], UIScreen.screenWidth * 0.05 )
                 HStack{
                     Button(action : {
                         let utterence = AVSpeechUtterance(string: hangeuls[num[1]].word)
@@ -162,96 +165,95 @@ struct ClearView: View {
                         speak.speak(utterence)
                         self.Timer4.value = 0
                     }){
-                    ZStack{
+                        ZStack{
                             RoundedRectangle(cornerRadius: 10.0)
-                            .fill(ColorManage.button)
+                                .fill(ColorManage.button)
                             VStack{
-                                Text("\(hangeuls[num[1]].word)")
-                                    .foregroundColor(ColorManage.buttontext)
-                                    .font(.system(size: UIScreen.screenWidth * 0.13))
-                                    .opacity(0.6)
+                                if num.count > 4 {
+                                    Text("\(hangeuls[num[1]].word)")
+                                        .foregroundColor(ColorManage.buttontext)
+                                        .font(.system(size: UIScreen.screenWidth * 0.13))
+                                        .opacity(0.6)
+                                }
                             }
+                        }
                     }
-                    }.frame(width: UIScreen.screenWidth * 0.45, height: UIScreen.screenHeight * 0.09)
+                    .frame(width: UIScreen.screenWidth * 0.45, height: UIScreen.screenHeight * 0.09)
                     Button(action : {
                         let utterence = AVSpeechUtterance(string: hangeuls[num[0]].word)
                         utterence.voice = AVSpeechSynthesisVoice(language: "ko-KR")
-                        if(self.Timer5.value < 3){
+                        if(self.Timer5.value < 3) {
                             utterence.rate = 0.1
                         }
-                        else{
+                        else {
                             utterence.rate = 0.5
                         }
                         
                         speak.speak(utterence)
                         self.Timer5.value = 0
                     }){
-                    ZStack{
+                        ZStack{
                             RoundedRectangle(cornerRadius: 10.0)
-                            .fill(ColorManage.button)
+                                .fill(ColorManage.button)
                             VStack{
-                                Text("\(hangeuls[num[0]].word)")
-                                    .foregroundColor(ColorManage.buttontext)
-                                    .font(.system(size: UIScreen.screenWidth * 0.13))
-                                    .opacity(0.6)
+                                if num.count > 4 {
+                                    Text("\(hangeuls[num[0]].word)")
+                                        .foregroundColor(ColorManage.buttontext)
+                                        .font(.system(size: UIScreen.screenWidth * 0.13))
+                                        .opacity(0.6)
+                                }
                             }
+                        }
                     }
-                    }.frame(width: UIScreen.screenWidth * 0.45, height: UIScreen.screenHeight * 0.09)
-                }.padding(.bottom, UIScreen.screenHeight * 0.015)
-                    .padding([.leading, .trailing], UIScreen.screenWidth * 0.05 )
+                    .frame(width: UIScreen.screenWidth * 0.45, height: UIScreen.screenHeight * 0.09)
+                }
+                .padding(.bottom, UIScreen.screenHeight * 0.015)
+                .padding([.leading, .trailing], UIScreen.screenWidth * 0.05 )
                 HStack{
                     Button(action : {
                         showModal.toggle()
                     }){
-                    ZStack{
+                        ZStack{
                             RoundedRectangle(cornerRadius: 10.0)
-                            .fill(ColorManage.clean)
+                                .fill(ColorManage.clean)
                             VStack{
                                 Text("Syllable")
                                     .foregroundColor(ColorManage.button)
                                     .font(.system(size: UIScreen.screenWidth * 0.05))
                                     .opacity(0.6)
                             }
+                        }
                     }
-                    }.frame(width: UIScreen.screenWidth * 0.45, height: UIScreen.screenHeight * 0.058)
+                    .frame(width: UIScreen.screenWidth * 0.45, height: UIScreen.screenHeight * 0.058)
                     
                     Button(action : {
                         page = 1
                     }){
-                    ZStack{
+                        ZStack{
                             RoundedRectangle(cornerRadius: 10.0)
-                            .fill(ColorManage.plus)
+                                .fill(ColorManage.plus)
                             VStack{
                                 Text("Restart")
                                     .foregroundColor(ColorManage.button)
                                     .font(.system(size: UIScreen.screenWidth * 0.05))
                                     .opacity(0.6)
                             }
-                    }
-                    }.frame(width: UIScreen.screenWidth * 0.45, height: UIScreen.screenHeight * 0.058)
-                }.padding(.bottom, UIScreen.screenHeight * 0.1)
-                    .padding([.leading, .trailing], UIScreen.screenWidth * 0.05 )
-                    
-                .alert(isPresented: $showAlert) {
-                            Alert(title: Text("Thank you for playing so far"),
-                                  message: Text("Please keep interest for Hangeul."),
-                                  dismissButton: .default(Text("RETRUN")))
                         }
+                    }
+                    .frame(width: UIScreen.screenWidth * 0.45, height: UIScreen.screenHeight * 0.058)
+                }
+                .padding(.bottom, UIScreen.screenHeight * 0.1)
+                .padding([.leading, .trailing], UIScreen.screenWidth * 0.05 )
+                
+                .alert(isPresented: $showAlert) {
+                    Alert(title: Text("Thank you for playing so far"),
+                          message: Text("Please keep interest for Hangeul."),
+                          dismissButton: .default(Text("RETRUN")))
+                }
                 .sheet(isPresented: self.$showModal) {
                     LettersView()
                 }
-//                NavigationLink(destination: ContentView(), isActive: $nextView) {
-//                                    EmptyView()
-//                                }.disabled(true)
-//        }
-            
+            }
         }
-//        .navigationBarTitle("")
-//        .navigationBarTitleDisplayMode(.inline)
-        }
-       
-//        .navigationBarHidden(true)
-
-        
     }
 }

--- a/Hangeul/ContentView.swift
+++ b/Hangeul/ContentView.swift
@@ -23,42 +23,29 @@ struct ContentView: View {
     let soundplayer = SoundPlayer()
     var i = Int.random(in: 0...154)
     
-    
-    
-    
     var body: some View {
         ZStack{
-            if #available(iOS 14.0, *) {
-                ColorManage.background
-                    .ignoresSafeArea()
-            } else {
-                ColorManage.background
-                    .edgesIgnoringSafeArea(.all)
-            }
+            ColorManage.background
+                .ignoresSafeArea()
             VStack{
                 MainBox(text: hangeuls[i].word)
                 SolBox(letterFirst: letterFirst, letterSecond: letterSecond, check1: $firstText, check2: $secondText)
                 EditBox(text: hangeuls[i].word, letterKorea: hangeuls[i].word, letterEnglish: hangeuls[i].english, letterPron: hangeuls[i].pron, check: $secondText)
                 BodyBox(page: $page, han: $han, text: hangeuls[i].word, letterFirst: letterFirst, check1: $firstText, check2: $secondText, nextView: $nextView, clearAlert: $clearAlert, showAlert: $showAlert, letterArray: hangeuls[i].stateA)
-                
                     .alert(isPresented: $showAlert) {
                         Alert(title: Text("Didn't Match"),
                               message: Text("Please try again."),
                               dismissButton: .default(Text("RETRUN")))
                     }
-                
             }
-        }.onAppear(){
+        }
+        .onAppear() {
             letterFirst = String(hangeuls[i].word.prefix(1))
             letterSecond = String(hangeuls[i].word.suffix(1))
             num = []
             num.append(i)
             han = hangeuls[i]
         }
-        
-        
-        
-        
     }
 }
 

--- a/Hangeul/FifthView.swift
+++ b/Hangeul/FifthView.swift
@@ -25,41 +25,35 @@ struct FifthView: View {
     
     
     var body: some View {
-//        NavigationView{
-            ZStack{
-                if #available(iOS 14.0, *) {
-                    ColorManage.background
-                        .ignoresSafeArea()
-                } else {
-                    ColorManage.background
-                        .edgesIgnoringSafeArea(.all)
+        ZStack{
+            ColorManage.background
+                .ignoresSafeArea()
+            VStack{
+                MainBox(text: hangeuls[i].word)
+                SolBox(letterFirst: letterFirst, letterSecond: letterSecond, check1: $firstText, check2: $secondText)
+                EditBox(text: hangeuls[i].word, letterKorea: hangeuls[i].word, letterEnglish: hangeuls[i].english, letterPron: hangeuls[i].pron, check: $secondText)
+                BodyBox(page: $page, han: $han, text: hangeuls[i].word, letterFirst: letterFirst, check1: $firstText, check2: $secondText, nextView: $nextView, clearAlert: $clearAlert, showAlert: $showAlert, letterArray: hangeuls[i].stateA)
+                
+                    .alert(isPresented: $showAlert) {
+                        Alert(title: Text("Didn't Match"),
+                              message: Text("Please try again."),
+                              dismissButton: .default(Text("RETRUN")))
+                    }
+            }.onAppear() {
+                while(!check) {
+                    if(!num.contains(i)) {
+                        num.append(i)
+                        check = true
+                    }
+                    else {
+                        i = Int.random(in: 0...154)
+                    }
                 }
-                VStack{
-                    MainBox(text: hangeuls[i].word)
-                    SolBox(letterFirst: letterFirst, letterSecond: letterSecond, check1: $firstText, check2: $secondText)
-                    EditBox(text: hangeuls[i].word, letterKorea: hangeuls[i].word, letterEnglish: hangeuls[i].english, letterPron: hangeuls[i].pron, check: $secondText)
-                    BodyBox(page: $page, han: $han, text: hangeuls[i].word, letterFirst: letterFirst, check1: $firstText, check2: $secondText, nextView: $nextView, clearAlert: $clearAlert, showAlert: $showAlert, letterArray: hangeuls[i].stateA)
-                    
-                        .alert(isPresented: $showAlert) {
-                            Alert(title: Text("Didn't Match"),
-                                  message: Text("Please try again."),
-                                  dismissButton: .default(Text("RETRUN")))
-                        }
-        }.onAppear(){
-            while(!check){
-                if(!num.contains(i)){
-                    num.append(i)
-                    check = true
-                }
-                else{
-                    i = Int.random(in: 0...154)
-                }
+                letterFirst = String(hangeuls[i].word.prefix(1))
+                letterSecond = String(hangeuls[i].word.suffix(1))
+                han = hangeuls[i]
             }
-            letterFirst = String(hangeuls[i].word.prefix(1))
-            letterSecond = String(hangeuls[i].word.suffix(1))
-            han = hangeuls[i]
-            
         }
-    }}
+    }
 }
 

--- a/Hangeul/FourthView.swift
+++ b/Hangeul/FourthView.swift
@@ -25,51 +25,35 @@ struct FourthView: View {
     
     
     var body: some View {
-//        NavigationView{
-            ZStack{
-                if #available(iOS 14.0, *) {
-                    ColorManage.background
-                        .ignoresSafeArea()
-                } else {
-                    ColorManage.background
-                        .edgesIgnoringSafeArea(.all)
-                }
-                VStack{
-                    MainBox(text: hangeuls[i].word)
-                    SolBox(letterFirst: letterFirst, letterSecond: letterSecond, check1: $firstText, check2: $secondText)
-                    EditBox(text: hangeuls[i].word, letterKorea: hangeuls[i].word, letterEnglish: hangeuls[i].english, letterPron: hangeuls[i].pron, check: $secondText)
-                    BodyBox(page: $page, han: $han, text: hangeuls[i].word, letterFirst: letterFirst, check1: $firstText, check2: $secondText, nextView: $nextView, clearAlert: $clearAlert, showAlert: $showAlert, letterArray: hangeuls[i].stateA)
-                    
-                        .alert(isPresented: $showAlert) {
-                            Alert(title: Text("Didn't Match"),
-                                  message: Text("Please try again."),
-                                  dismissButton: .default(Text("RETRUN")))
-                        }
-//                    NavigationLink(destination: FifthView(num: num), isActive: $nextView) {
-//                        EmptyView()
-//                    }.disabled(true)
-                }
-            }.onAppear(){
-                while(!check){
-                    if(!num.contains(i)){
-                        num.append(i)
-                        check = true
-                    }
-                    else{
-                        i = Int.random(in: 0...154)
-                    }
-                }
-                letterFirst = String(hangeuls[i].word.prefix(1))
-                letterSecond = String(hangeuls[i].word.suffix(1))
-                han = hangeuls[i]
+        ZStack{
+            ColorManage.background
+                .ignoresSafeArea()
+            VStack{
+                MainBox(text: hangeuls[i].word)
+                SolBox(letterFirst: letterFirst, letterSecond: letterSecond, check1: $firstText, check2: $secondText)
+                EditBox(text: hangeuls[i].word, letterKorea: hangeuls[i].word, letterEnglish: hangeuls[i].english, letterPron: hangeuls[i].pron, check: $secondText)
+                BodyBox(page: $page, han: $han, text: hangeuls[i].word, letterFirst: letterFirst, check1: $firstText, check2: $secondText, nextView: $nextView, clearAlert: $clearAlert, showAlert: $showAlert, letterArray: hangeuls[i].stateA)
                 
+                    .alert(isPresented: $showAlert) {
+                        Alert(title: Text("Didn't Match"),
+                              message: Text("Please try again."),
+                              dismissButton: .default(Text("RETRUN")))
+                    }
             }
-//            .navigationBarTitle("")
-//            .navigationBarTitleDisplayMode(.inline)
+        }.onAppear() {
+            while(!check) {
+                if(!num.contains(i)) {
+                    num.append(i)
+                    check = true
+                }
+                else {
+                    i = Int.random(in: 0...154)
+                }
+            }
+            letterFirst = String(hangeuls[i].word.prefix(1))
+            letterSecond = String(hangeuls[i].word.suffix(1))
+            han = hangeuls[i]
         }
-        
-//        .navigationBarHidden(true)
-        
-        
     }
+}
 

--- a/Hangeul/LettersView.swift
+++ b/Hangeul/LettersView.swift
@@ -23,13 +23,8 @@ struct LettersView: View {
     var body: some View {
         ScrollView{
             ZStack{
-                if #available(iOS 14.0, *) {
-                    ColorManage.background
-                        .ignoresSafeArea()
-                } else {
-                    ColorManage.background
-                        .edgesIgnoringSafeArea(.all)
-                }
+                ColorManage.background
+                    .ignoresSafeArea()
                 VStack{
                     VStack{
                         HStack{
@@ -76,8 +71,10 @@ struct LettersView: View {
                     }
                     VStack{
                         
-                    }.frame(height: UIScreen.screenHeight * 0.3 )
-                }.padding([.leading, .trailing], UIScreen.screenWidth * 0.05 )
+                    }
+                    .frame(height: UIScreen.screenHeight * 0.3 )
+                }
+                .padding([.leading, .trailing], UIScreen.screenWidth * 0.05 )
                 
                 
             }
@@ -117,6 +114,7 @@ struct LettersBox: View{
                         .opacity(0.6)
                 }
             }
-        }.frame(width: UIScreen.screenHeight * 0.09, height: UIScreen.screenHeight * 0.09)
+        }
+        .frame(width: UIScreen.screenHeight * 0.09, height: UIScreen.screenHeight * 0.09)
     }
 }

--- a/Hangeul/SecondView.swift
+++ b/Hangeul/SecondView.swift
@@ -25,54 +25,36 @@ struct SecondView: View {
     
     
     var body: some View {
-//        NavigationView{
-            ZStack{
-                if #available(iOS 14.0, *) {
-                    ColorManage.background
-                        .ignoresSafeArea()
-                } else {
-                    ColorManage.background
-                        .edgesIgnoringSafeArea(.all)
-                }
-                VStack{
-                    MainBox(text: hangeuls[i].word)
-                    SolBox(letterFirst: letterFirst, letterSecond: letterSecond, check1: $firstText, check2: $secondText)
-                    EditBox(text: hangeuls[i].word, letterKorea: hangeuls[i].word, letterEnglish: hangeuls[i].english, letterPron: hangeuls[i].pron, check: $secondText)
-                    BodyBox(page: $page, han: $han, text: hangeuls[i].word, letterFirst: letterFirst, check1: $firstText, check2: $secondText, nextView: $nextView, clearAlert: $clearAlert, showAlert: $showAlert, letterArray: hangeuls[i].stateA)
-                    
-                        .alert(isPresented: $showAlert) {
-                            Alert(title: Text("Didn't Match"),
-                                  message: Text("Please try again."),
-                                  dismissButton: .default(Text("RETRUN")))
-                        }
-//                    NavigationLink(destination: ThirdView(num: num), isActive: $nextView) {
-//                        EmptyView()
-//                    }.disabled(true)
-//                }
+        ZStack{
+            ColorManage.background
+                .ignoresSafeArea()
+            VStack{
+                MainBox(text: hangeuls[i].word)
+                SolBox(letterFirst: letterFirst, letterSecond: letterSecond, check1: $firstText, check2: $secondText)
+                EditBox(text: hangeuls[i].word, letterKorea: hangeuls[i].word, letterEnglish: hangeuls[i].english, letterPron: hangeuls[i].pron, check: $secondText)
+                BodyBox(page: $page, han: $han, text: hangeuls[i].word, letterFirst: letterFirst, check1: $firstText, check2: $secondText, nextView: $nextView, clearAlert: $clearAlert, showAlert: $showAlert, letterArray: hangeuls[i].stateA)
+                
+                    .alert(isPresented: $showAlert) {
+                        Alert(title: Text("Didn't Match"),
+                              message: Text("Please try again."),
+                              dismissButton: .default(Text("RETRUN")))
+                    }
             }
-//            .navigationBarTitle("")
-//            .navigationBarTitleDisplayMode(.inline)
-        }.onAppear(){
-            while(!check){
-                if(!num.contains(i)){
+        }
+        .onAppear() {
+            while(!check) {
+                if(!num.contains(i)) {
                     num.append(i)
                     check = true
                 }
-                else{
+                else {
                     i = Int.random(in: 0...154)
                 }
             }
             letterFirst = String(hangeuls[i].word.prefix(1))
             letterSecond = String(hangeuls[i].word.suffix(1))
             han = hangeuls[i]
-            
-            
-            
         }
-        
-//        .navigationBarHidden(true)
-        
-        
     }
 }
 

--- a/Hangeul/ThirdView.swift
+++ b/Hangeul/ThirdView.swift
@@ -25,52 +25,34 @@ struct ThirdView: View {
     
     
     var body: some View {
-//        NavigationView{
-            ZStack{
-                if #available(iOS 14.0, *) {
-                    ColorManage.background
-                        .ignoresSafeArea()
-                } else {
-                    ColorManage.background
-                        .edgesIgnoringSafeArea(.all)
-                }
-                VStack{
-                    MainBox(text: hangeuls[i].word)
-                    SolBox(letterFirst: letterFirst, letterSecond: letterSecond, check1: $firstText, check2: $secondText)
-                    EditBox(text: hangeuls[i].word, letterKorea: hangeuls[i].word, letterEnglish: hangeuls[i].english, letterPron: hangeuls[i].pron, check: $secondText)
-                    BodyBox(page: $page, han: $han, text: hangeuls[i].word, letterFirst: letterFirst, check1: $firstText, check2: $secondText, nextView: $nextView, clearAlert: $clearAlert, showAlert: $showAlert, letterArray: hangeuls[i].stateA)
-                    
-                        .alert(isPresented: $showAlert) {
-                            Alert(title: Text("Didn't Match"),
-                                  message: Text("Please try again."),
-                                  dismissButton: .default(Text("RETRUN")))
-                        }
-//                    NavigationLink(destination: FourthView(num: num), isActive: $nextView) {
-//                        EmptyView()
-//                    }.disabled(true)
-//                }
+        ZStack{
+            ColorManage.background
+                .ignoresSafeArea()
+            VStack{
+                MainBox(text: hangeuls[i].word)
+                SolBox(letterFirst: letterFirst, letterSecond: letterSecond, check1: $firstText, check2: $secondText)
+                EditBox(text: hangeuls[i].word, letterKorea: hangeuls[i].word, letterEnglish: hangeuls[i].english, letterPron: hangeuls[i].pron, check: $secondText)
+                BodyBox(page: $page, han: $han, text: hangeuls[i].word, letterFirst: letterFirst, check1: $firstText, check2: $secondText, nextView: $nextView, clearAlert: $clearAlert, showAlert: $showAlert, letterArray: hangeuls[i].stateA)
+                
+                    .alert(isPresented: $showAlert) {
+                        Alert(title: Text("Didn't Match"),
+                              message: Text("Please try again."),
+                              dismissButton: .default(Text("RETRUN")))
+                    }
             }
-//            .navigationBarTitle("")
-//            .navigationBarTitleDisplayMode(.inline)
-        }.onAppear(){
-            while(!check){
-                if(!num.contains(i)){
+        }.onAppear() {
+            while(!check) {
+                if(!num.contains(i)) {
                     num.append(i)
                     check = true
                 }
-                else{
+                else {
                     i = Int.random(in: 0...154)
                 }
-                
             }
             letterFirst = String(hangeuls[i].word.prefix(1))
             letterSecond = String(hangeuls[i].word.suffix(1))
             han = hangeuls[i]
-            
         }
-        
-//        .navigationBarHidden(true)
-        
-        
     }
 }

--- a/Hangeul/welcomeView.swift
+++ b/Hangeul/welcomeView.swift
@@ -14,17 +14,10 @@ struct WelcomeView: View {
     let soundplayer = SoundPlayer()
     
     var body: some View {
-        //        NavigationView{
         ZStack{
-            if #available(iOS 14.0, *) {
-                ColorManage.background
-                    .ignoresSafeArea()
-            } else {
-                ColorManage.background
-                    .edgesIgnoringSafeArea(.all)
-            }
+            ColorManage.background
             VStack{
-                HStack {
+                HStack{
                     ZStack{
                         RoundedRectangle(cornerRadius: 10.0)
                             .fill(ColorManage.button)
@@ -34,8 +27,9 @@ struct WelcomeView: View {
                                 .font(.system(size: UIScreen.screenWidth * 0.28))
                         }
                     }
-                }.frame(width: UIScreen.screenWidth * 0.90, height: UIScreen.screenHeight * 0.25)
-                    .padding(.bottom, UIScreen.screenHeight * 0.01)
+                }
+                .frame(width: UIScreen.screenWidth * 0.90, height: UIScreen.screenHeight * 0.25)
+                .padding(.bottom, UIScreen.screenHeight * 0.01)
                 HStack{
                     Text("Tap to Start")
                         .foregroundColor(ColorManage.plus)
@@ -43,7 +37,6 @@ struct WelcomeView: View {
                         .opacity(0.6)
                     
                 }
-                
                 .padding(.bottom, UIScreen.screenHeight * 0.01)
                 
                 HStack{
@@ -52,25 +45,13 @@ struct WelcomeView: View {
                         .font(.system(size: UIScreen.screenWidth * 0.05))
                         .multilineTextAlignment(.center)
                         .opacity(0.6)
-                }.padding([.leading, .trailing], UIScreen.screenWidth * 0.05)
-            }.onTapGesture{
+                }
+                .padding([.leading, .trailing], UIScreen.screenWidth * 0.05)
+            }
+            .onTapGesture{
                 page = 1
             }
-            
-            
-            
-            //                NavigationLink(destination: ContentView(), isActive: $nextView) {
-            //                                    EmptyView()
-            //                                }.disabled(true)
-            //        }
-            //
-            //        .navigationBarTitle("")
-            //        .navigationBarTitleDisplayMode(.inline)
         }
-        //        .navigationBarHidden(true)
-        
-        
-        
     }
 }
 


### PR DESCRIPTION
@LeeSungNo-ian
@jeong-hyeonHwang
@commitcomplete
@yeniful

## Outline
- #7 

## Work Contents
- 지속적으로 발생하고 있는 충돌 해결
- 사용하지 않는 코드 및 예외 처리 제거
- 가독성 업데이트
<img width="1103" alt="image" src="https://user-images.githubusercontent.com/63584245/202437235-136cc583-ca42-42ab-b83c-0e0439af86fb.png">



## Trouble Point 
### 1. ClearView에서 restart 버튼을 누르면 발생하는 Crush

  - **Trouble Situation**
    -  ClearView에서 restart를 눌러 페이지에 바인딩된 태그 값을 변경하여 첫 번째 페이지로 넘겨줄 때 ContentView의 `.onAppear`가 먼저 동작하여 문제들이 담겨있는 `num` 배열이 초기화 되는데 이때 ClearView에서 사용하는 @State 처리된 `num`배열이 비워지기에 발생
<img width="646" alt="image" src="https://user-images.githubusercontent.com/63584245/201942799-949a71ed-6af9-41d5-b4ef-a1f972eaf801.png">

 - **Trouble Shooting**
    - `num` 배열 요소들의 숫자가 일정 이하로 떨어지면 ClearView에서 `num` 배열에 접근하지 않도록 수정
  
```swift
if num.count > 4 {

}
```