### PR TITLE
Fix: 3음절 문제 화면 디자인 수정

### DIFF
--- a/Hangeul.xcodeproj/project.pbxproj
+++ b/Hangeul.xcodeproj/project.pbxproj
@@ -467,7 +467,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "\"Hangeul/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -475,6 +475,7 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
@@ -483,7 +484,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = edu.coin.Hangeul;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -498,7 +499,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "\"Hangeul/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -506,6 +507,7 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
@@ -514,7 +516,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = edu.coin.Hangeul;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Hangeul/GameSession.swift
+++ b/Hangeul/GameSession.swift
@@ -19,6 +19,7 @@ final class GameSession: ObservableObject {
 
     private let requestedRoundCount: Int
     private let deterministicSelection: Bool
+    private let uiTestingWordID: Int?
     private let loader: Loader
     private var allWords: [HangeulWord] = []
     private var puzzles: [HangulPuzzle] = []
@@ -31,9 +32,11 @@ final class GameSession: ObservableObject {
     ) {
         requestedRoundCount = max(1, roundCount)
         self.loader = loader
+        let processArguments = ProcessInfo.processInfo.arguments
         self.deterministicSelection =
             deterministicSelection
-            ?? ProcessInfo.processInfo.arguments.contains("--ui-testing")
+            ?? processArguments.contains("--ui-testing")
+        uiTestingWordID = Self.uiTestingWordID(in: processArguments)
 
         if let words = words {
             allWords = words
@@ -57,17 +60,24 @@ final class GameSession: ObservableObject {
 
     func startGame() {
         let uniqueWords = wordsWithUniqueSpelling(from: allWords)
-        guard !uniqueWords.isEmpty else {
+        let playableWords: [HangeulWord]
+        if let uiTestingWordID {
+            playableWords = uniqueWords.filter { $0.id == uiTestingWordID }
+        } else {
+            playableWords = uniqueWords
+        }
+
+        guard !playableWords.isEmpty else {
             route = .failure("There are no valid Hangeul words to play.")
             return
         }
 
-        let roundCount = min(requestedRoundCount, uniqueWords.count)
+        let roundCount = min(requestedRoundCount, playableWords.count)
         let selectedWords: [HangeulWord]
         if deterministicSelection {
-            selectedWords = Array(uniqueWords.sorted { $0.id < $1.id }.prefix(roundCount))
+            selectedWords = Array(playableWords.sorted { $0.id < $1.id }.prefix(roundCount))
         } else {
-            selectedWords = Array(uniqueWords.shuffled().prefix(roundCount))
+            selectedWords = Array(playableWords.shuffled().prefix(roundCount))
         }
 
         do {
@@ -102,6 +112,14 @@ final class GameSession: ObservableObject {
     private func wordsWithUniqueSpelling(from words: [HangeulWord]) -> [HangeulWord] {
         var seen = Set<String>()
         return words.filter { seen.insert($0.word).inserted }
+    }
+
+    private static func uiTestingWordID(in arguments: [String]) -> Int? {
+        guard arguments.contains("--ui-testing") else { return nil }
+
+        let prefix = "--ui-testing-word-id="
+        guard let argument = arguments.first(where: { $0.hasPrefix(prefix) }) else { return nil }
+        return Int(argument.dropFirst(prefix.count))
     }
 
     private func resetRoundState() {

--- a/Hangeul/PuzzleComponents.swift
+++ b/Hangeul/PuzzleComponents.swift
@@ -61,7 +61,7 @@ struct SyllableProgressRow: View {
 
     var body: some View {
         Group {
-            if syllables.count <= 2 {
+            if syllables.count <= 3 {
                 HStack {
                     tiles
                 }

--- a/Hangeul/PuzzleView.swift
+++ b/Hangeul/PuzzleView.swift
@@ -37,7 +37,8 @@ struct PuzzleView: View {
     }
 
     private var usesOriginalLayout: Bool {
-        puzzle.syllables.count == 2 && puzzle.candidates.count == HangulPuzzle.defaultCandidateCount
+        (2...3).contains(puzzle.syllables.count)
+            && puzzle.candidates.count == HangulPuzzle.defaultCandidateCount
     }
 
     private var puzzleContent: some View {
@@ -80,6 +81,7 @@ struct PuzzleView: View {
                 Text("Pick all the Lettes for This Box.")
                     .font(.system(size: UIScreen.screenWidth * 0.04))
                     .foregroundColor(AppColors.buttonText)
+                    .accessibilityIdentifier("puzzle-instruction")
             }
         }
         .frame(width: UIScreen.screenWidth * 0.90, height: UIScreen.screenHeight * 0.03)

--- a/HangeulUITests/HangeulUITests.swift
+++ b/HangeulUITests/HangeulUITests.swift
@@ -72,6 +72,110 @@ final class HangeulUITests: XCTestCase {
         assertWord("우리")
     }
 
+    func testThreeSyllablePuzzleUsesTwoSyllableLayout() {
+        let twoSyllableLayout = capturePuzzleLayout(wordID: 1, attachmentName: "2-syllable")
+        let threeSyllableLayout = capturePuzzleLayout(wordID: 1002, attachmentName: "3-syllable")
+
+        assertFramesEqual(
+            threeSyllableLayout.wordCard,
+            twoSyllableLayout.wordCard,
+            component: "word card"
+        )
+        XCTAssertLessThanOrEqual(
+            threeSyllableLayout.wordText.height,
+            twoSyllableLayout.wordText.height + 1,
+            "The three-syllable word must remain on one line."
+        )
+        XCTAssertEqual(
+            threeSyllableLayout.wordText.midY,
+            twoSyllableLayout.wordText.midY,
+            accuracy: 1,
+            "The word must stay vertically centered in its card."
+        )
+        assertFramesEqual(
+            threeSyllableLayout.instruction,
+            twoSyllableLayout.instruction,
+            component: "instruction"
+        )
+
+        for index in twoSyllableLayout.candidates.indices {
+            assertFramesEqual(
+                threeSyllableLayout.candidates[index],
+                twoSyllableLayout.candidates[index],
+                component: "candidate \(index)"
+            )
+        }
+
+        assertFramesEqual(
+            threeSyllableLayout.cleanButton,
+            twoSyllableLayout.cleanButton,
+            component: "clean button"
+        )
+        assertFramesEqual(
+            threeSyllableLayout.confirmButton,
+            twoSyllableLayout.confirmButton,
+            component: "confirm button"
+        )
+
+        XCTAssertEqual(twoSyllableLayout.progressTiles.count, 2)
+        XCTAssertEqual(threeSyllableLayout.progressTiles.count, 3)
+        guard
+            let referenceFirstTile = twoSyllableLayout.progressTiles.first,
+            let referenceLastTile = twoSyllableLayout.progressTiles.last,
+            let actualFirstTile = threeSyllableLayout.progressTiles.first,
+            let actualLastTile = threeSyllableLayout.progressTiles.last
+        else {
+            XCTFail("The compared layouts have no progress tiles.")
+            return
+        }
+        for tile in threeSyllableLayout.progressTiles {
+            XCTAssertEqual(
+                tile.width,
+                referenceFirstTile.width,
+                accuracy: 1
+            )
+            XCTAssertEqual(
+                tile.height,
+                referenceFirstTile.height,
+                accuracy: 1
+            )
+            XCTAssertEqual(
+                tile.midY,
+                referenceFirstTile.midY,
+                accuracy: 1
+            )
+        }
+
+        let referenceCenterX = (referenceFirstTile.minX + referenceLastTile.maxX) / 2
+        let actualCenterX = (actualFirstTile.minX + actualLastTile.maxX) / 2
+        XCTAssertEqual(
+            actualCenterX,
+            referenceCenterX,
+            accuracy: 1,
+            "The progress row must stay horizontally centered."
+        )
+
+        let referenceSpacing =
+            twoSyllableLayout.progressTiles[1].minX
+            - twoSyllableLayout.progressTiles[0].maxX
+        for (leftTile, rightTile) in zip(
+            threeSyllableLayout.progressTiles,
+            threeSyllableLayout.progressTiles.dropFirst()
+        ) {
+            XCTAssertLessThanOrEqual(
+                leftTile.maxX,
+                rightTile.minX,
+                "Progress tiles must not overlap."
+            )
+            XCTAssertEqual(
+                rightTile.minX - leftTile.maxX,
+                referenceSpacing,
+                accuracy: 1,
+                "Progress tile spacing must match the two-syllable layout."
+            )
+        }
+    }
+
     private func solveSyllable(with jamo: [String]) {
         for value in jamo {
             candidateButton(label: value).tap()
@@ -91,9 +195,88 @@ final class HangeulUITests: XCTestCase {
         return element
     }
 
+    private func capturePuzzleLayout(wordID: Int, attachmentName: String) -> PuzzleLayoutSnapshot {
+        app.terminate()
+        app = XCUIApplication()
+        app.launchArguments = ["--ui-testing", "--ui-testing-word-id=\(wordID)"]
+        app.launch()
+
+        let startButton = app.buttons["start-game"]
+        XCTAssertTrue(startButton.waitForExistence(timeout: 5))
+        startButton.tap()
+
+        let wordCard = app.buttons["word-audio"]
+        let instruction = app.staticTexts["puzzle-instruction"]
+        let cleanButton = app.buttons["action-clean"]
+        let confirmButton = app.buttons["confirm-selection"]
+        XCTAssertTrue(wordCard.waitForExistence(timeout: 5))
+        XCTAssertTrue(instruction.waitForExistence(timeout: 2))
+        XCTAssertTrue(cleanButton.waitForExistence(timeout: 2))
+        XCTAssertTrue(confirmButton.waitForExistence(timeout: 2))
+
+        let wordText = wordCard.descendants(matching: .staticText).firstMatch
+        XCTAssertTrue(wordText.exists)
+
+        let firstCandidate = app.buttons["candidate-0"]
+        XCTAssertTrue(firstCandidate.waitForExistence(timeout: 2))
+        let candidates = (0..<12).map { index in
+            let candidate = app.buttons["candidate-\(index)"]
+            XCTAssertTrue(candidate.exists)
+            XCTAssertTrue(candidate.isHittable)
+            return candidate.frame
+        }
+
+        let progressQuery = app.buttons.matching(
+            NSPredicate(format: "label CONTAINS %@", "syllable")
+        )
+        let progressTiles = progressQuery.allElementsBoundByIndex.map(\.frame)
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "\(attachmentName)-layout"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+
+        return PuzzleLayoutSnapshot(
+            wordCard: wordCard.frame,
+            wordText: wordText.frame,
+            instruction: instruction.frame,
+            candidates: candidates,
+            cleanButton: cleanButton.frame,
+            confirmButton: confirmButton.frame,
+            progressTiles: progressTiles
+        )
+    }
+
+    private func assertFramesEqual(
+        _ actual: CGRect,
+        _ expected: CGRect,
+        component: String,
+        accuracy: CGFloat = 1
+    ) {
+        XCTAssertEqual(actual.minX, expected.minX, accuracy: accuracy, "\(component) x changed")
+        XCTAssertEqual(actual.minY, expected.minY, accuracy: accuracy, "\(component) y changed")
+        XCTAssertEqual(actual.width, expected.width, accuracy: accuracy, "\(component) width changed")
+        XCTAssertEqual(
+            actual.height,
+            expected.height,
+            accuracy: accuracy,
+            "\(component) height changed"
+        )
+    }
+
     private func assertWord(_ expected: String) {
         let wordButton = app.buttons["Listen to \(expected)"]
         XCTAssertTrue(wordButton.waitForExistence(timeout: 5))
         XCTAssertEqual(wordButton.label, "Listen to \(expected)")
     }
+}
+
+private struct PuzzleLayoutSnapshot {
+    let wordCard: CGRect
+    let wordText: CGRect
+    let instruction: CGRect
+    let candidates: [CGRect]
+    let cleanButton: CGRect
+    let confirmButton: CGRect
+    let progressTiles: [CGRect]
 }


### PR DESCRIPTION
## Outline
- 2음절 화면 디자인을 기준으로 3음절 문제의 배치 깨짐 수정

## Work Contents
- 3음절, 12개 후보 문제도 기존 2음절 문제와 같은 중앙 정렬 레이아웃 적용
- 3개의 음절 진행 칸을 기존 2음절과 같은 `HStack` 중앙 배치로 통일
- 4음절 이상 또는 비표준 후보 수에 대한 스크롤 fallback 유지
- UI 테스트에서 특정 문제 ID를 선택할 수 있는 테스트 전용 실행 인자 추가
- 2음절과 3음절 화면 구성요소의 위치, 크기, 간격을 비교하는 UI 회귀 테스트 추가
- 앱 버전을 1.0.8, 빌드 번호를 3으로 갱신하고 비면제 암호화 미사용 선언 추가
- 기존 색상, 프레임 크기, 간격, 글꼴 및 버튼 디자인 유지

## Trouble Point
### 1. 3음절 문제가 2음절 문제와 다른 화면 배치 경로를 사용한다.

  - **Trouble Situation**
    - 2음절 문제만 기존 중앙 정렬 레이아웃을 사용하고 3음절 문제는 전체 콘텐츠가 세로 `ScrollView`에 포함된다.
    - 이 차이로 3음절 문제의 카드, 안내문, 후보 타일과 하단 버튼이 2음절 화면보다 위로 이동한다.
    - 음절 진행 칸도 3음절부터 수평 스크롤 레이아웃으로 전환되어 기존 화면과 정렬 방식이 달라진다.

  - **Trouble Shooting**
    - 12개 후보를 사용하는 2음절과 3음절 문제는 동일한 중앙 정렬 레이아웃을 사용하도록 조건을 확장하였다.
    - 최대 3개의 음절 진행 칸은 기존 `HStack`에 배치하고 4음절 이상에서만 수평 스크롤 fallback을 사용하도록 변경하였다.
    - 기존 2음절 화면의 색상, 컴포넌트 크기, 간격과 글꼴 값은 변경하지 않았다.

### 2. 3음절 화면 배치를 자동으로 재현하고 비교할 수 없다.

  - **Trouble Situation**
    - 기존 UI 테스트의 결정적 문제 선택은 앞쪽의 2음절 문제만 실행하여 3음절 화면을 고정적으로 검증할 수 없다.
    - 화면 요소의 존재 여부만 확인하는 테스트로는 3음절 화면의 위치 이동이나 진행 칸 겹침을 감지하기 어렵다.

  - **Trouble Shooting**
    - `--ui-testing` 환경에서만 지정한 문제 ID를 선택할 수 있는 테스트 전용 실행 인자를 추가하였다.
    - 2음절과 3음절 문제의 단어 카드, 안내문, 후보 타일 12개, 하단 버튼 프레임을 직접 비교하도록 UI 테스트를 추가하였다.
    - 음절 진행 칸의 크기, 세로 위치, 중앙 정렬, 간격과 겹침 여부를 검증하고 두 화면의 스크린샷을 테스트 결과에 첨부하였다.
    - 수정 전 레이아웃 차이를 재현하고 수정 후 회귀 테스트, 전체 XCTest 29개, strict Swift format과 `git diff --check` 통과를 확인하였다.